### PR TITLE
fix(docs): response code of example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class ValidateWithOpenApi extends \N1215\OpenApiValidation\Laravel\Middleware\Va
             [
                 'message' =>  'failed to validate request',
             ],
-            Response::HTTP_INTERNAL_SERVER_ERROR
+            Response::HTTP_BAD_REQUEST
         );
     }
 


### PR DESCRIPTION
Hi! Thank you for your always helpful presentation.

Regarding the code example in the README, I think it would be better to indicate the request validation error as *Bad Request* instead of *Internal Server Error*.